### PR TITLE
Fetching Wallet details once payment is successfully executed

### DIFF
--- a/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/PaymentPopup/Details/index.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/PaymentPopup/Details/index.js
@@ -17,7 +17,7 @@ import { USDToAgi } from "../../../../../../../../../utility/PricingStrategy";
 
 export const paymentTypes = [{ value: "paypal", label: "Pay pal" }];
 
-const Details = ({ classes, initiatePayment, handleClose }) => {
+const Details = ({ classes, initiatePayment, handleClose, channelInfo }) => {
   const [payType, setPayType] = useState("default");
   const [amount, setAmount] = useState("");
   const [alert, setAlert] = useState({});
@@ -59,7 +59,12 @@ const Details = ({ classes, initiatePayment, handleClose }) => {
             </Typography>
           </div>
         </div>
-        <PaymentInfoCard title="Channel Balance" value=".00000000" unit />
+        <PaymentInfoCard
+          title="Channel Balance"
+          show={channelInfo.balanceInAgi}
+          value={channelInfo.balanceInAgi}
+          unit="AGI"
+        />
       </div>
 
       <div className={classes.dropDownTextfield}>

--- a/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/PaymentPopup/index.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/PaymentPopup/index.js
@@ -20,6 +20,7 @@ import { paymentActions } from "../../../../../../../../Redux/actionCreators";
 import { groupInfo } from "../../../../../../../../Redux/reducers/ServiceDetailsReducer";
 import { orderTypes } from "..";
 import Routes from "../../../../../../../../utility/constants/Routes";
+import { channelInfo } from "../../../../../../../../Redux/reducers/UserReducer";
 
 class CreateWalletPopup extends Component {
   state = {
@@ -119,7 +120,7 @@ class CreateWalletPopup extends Component {
   };
 
   render() {
-    const { classes, visible, paypalInProgress, orderType, title } = this.props;
+    const { classes, visible, paypalInProgress, orderType, title, channelInfo } = this.props;
     const { activeSection, privateKey, amount, item, quantity } = this.state;
 
     const progressText = ["Details", "Purchase", "Summary"];
@@ -131,6 +132,7 @@ class CreateWalletPopup extends Component {
             handleNextSection={this.handleNextSection}
             initiatePayment={this.handleInitiatePayment}
             handleClose={this.handleClose}
+            channelInfo={channelInfo}
           />
         ),
       },
@@ -194,6 +196,7 @@ class CreateWalletPopup extends Component {
 const mapStateToProps = state => ({
   paypalInProgress: state.paymentReducer.paypalInProgress,
   group: groupInfo(state),
+  channelInfo: channelInfo(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/PaymentPopup/index.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/PaymentPopup/index.js
@@ -56,7 +56,7 @@ class CreateWalletPopup extends Component {
   };
 
   handleClose = () => {
-    if (this.state.activeSection === 1) {
+    if (this.state.activeSection === 1 || this.state.activeSection === 2) {
       this.props.setVisibility(false);
     }
   };


### PR DESCRIPTION
1. Fetching Wallet details once payment is successfully executed
2. Allowing cancel if the `order/execute` fails