### PR TITLE
start/stop polling only if reqd.

### DIFF
--- a/src/Redux/actionCreators/UserActions.js
+++ b/src/Redux/actionCreators/UserActions.js
@@ -174,7 +174,6 @@ export const fetchUserDetails = async dispatch => {
     const { nickname, token, email, email_verified } = await fetchAuthenticatedUser();
     await dispatch(fetchUserProfile(token));
     if (email === null || email === undefined) {
-      //Username review - test for no authernticated user
       dispatch(noAuthenticatedUser);
       return;
     }
@@ -426,10 +425,6 @@ export const updateFirstTimeFetchWallet = value => dispatch => {
 const fetchWalletSuccess = response => dispatch => {
   if (!isEmpty(response.data.wallets)) {
     dispatch(updateWalletList(response.data.wallets));
-    // const defaultWallet = response.data.wallets.find(wallet => Boolean(wallet.is_default));
-    // if (!isEmpty(defaultWallet)) {
-    //   dispatch(updateWallet(defaultWallet));
-    // }
   }
 };
 

--- a/src/Redux/actionCreators/UserActions.js
+++ b/src/Redux/actionCreators/UserActions.js
@@ -27,7 +27,7 @@ export const UPDATE_IS_TERMS_ACCEPTED = "UPDATE_IS_TERMS_ACCEPTED";
 export const UPDATE_TRANSACTION_HISTORY = "UPDATE_TRANSACTION_HISTORY";
 export const UPDATE_FIRST_TIME_FETCH_WALLET = "FIRST_TIME_FETCH_WALLET";
 
-let walletPollingInterval;
+let walletPollingInterval = false;
 
 export const walletTypes = {
   GENERAL: "GENERAL",
@@ -465,12 +465,17 @@ export const fetchWalletLinkedProviders = async address => {
 };
 
 export const startWalletDetailsPolling = (orgId, groupId) => dispatch => {
-  walletPollingInterval = setInterval(() => dispatch(fetchWallet(orgId, groupId)), 15000);
-  return dispatch(fetchWallet(orgId, groupId));
+  if (!walletPollingInterval) {
+    walletPollingInterval = setInterval(() => dispatch(fetchWallet(orgId, groupId)), 15000);
+    return dispatch(fetchWallet(orgId, groupId));
+  }
 };
 
 export const stopWalletDetailsPolling = () => {
-  clearInterval(walletPollingInterval);
+  if (walletPollingInterval) {
+    clearInterval(walletPollingInterval);
+    walletPollingInterval = false;
+  }
 };
 
 const updateDefaultWalletAPI = (token, address) => {

--- a/src/Redux/reducers/PaymentReducer.js
+++ b/src/Redux/reducers/PaymentReducer.js
@@ -21,10 +21,10 @@ const paymentReducer = (state = InitialPaymentDetails, action) => {
 
 export const anyPendingTxn = state => {
   const { walletList } = state.userReducer;
-  const pendingTransactions = walletList.some(
+  const istransactionsPending = walletList.some(
     wallet => wallet.transactions && wallet.transactions.some(txn => txn.status === "PENDING")
   );
-  return pendingTransactions;
+  return istransactionsPending;
 };
 
 export default paymentReducer;

--- a/src/Redux/reducers/PaymentReducer.js
+++ b/src/Redux/reducers/PaymentReducer.js
@@ -19,4 +19,12 @@ const paymentReducer = (state = InitialPaymentDetails, action) => {
   }
 };
 
+export const anyPendingTxn = state => {
+  const { walletList } = state.userReducer;
+  const pendingTransactions = walletList.some(
+    wallet => wallet.transactions && wallet.transactions.some(txn => txn.status === "PENDING")
+  );
+  return pendingTransactions;
+};
+
 export default paymentReducer;

--- a/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/NextAction.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/NextAction.js
@@ -19,14 +19,28 @@ const NextAction = props => {
         type="blue"
         btnText="create wallet"
         onClick={() => setShowCreateWalletPopup(true)}
-        disabled={anyPendingTxn()}
+        disabled={anyPendingTxn}
       />
     );
   }
   if (isEmpty(channel)) {
-    return <StyledButton type="blue" btnText="link provider" onClick={() => setShowLinkProvider(true)} />;
+    return (
+      <StyledButton
+        type="blue"
+        btnText="link provider"
+        onClick={() => setShowLinkProvider(true)}
+        disabled={anyPendingTxn}
+      />
+    );
   }
-  return <StyledButton type="blue" btnText="continue" disabled={channel.balanceInAgi <= 0} onClick={handleContinue} />;
+  return (
+    <StyledButton
+      type="blue"
+      btnText="continue"
+      disabled={channel.balanceInAgi <= 0 || anyPendingTxn}
+      onClick={handleContinue}
+    />
+  );
 };
 
 export default NextAction;

--- a/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/index.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/index.js
@@ -46,12 +46,6 @@ const GeneralAccountWallet = props => {
     }
   }, [paypalInProgress.orderType]);
 
-  // const anyPendingTxn = () => {
-  //   const { wallet } = props;
-  //   const anyPending = wallet.transactions && wallet.transactions.some(txn => txn.status === "PENDING");
-  //   return anyPending;
-  // };
-
   return (
     <Fragment>
       <div className={classes.btnsContainer}>

--- a/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/index.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/index.js
@@ -14,6 +14,7 @@ import { paymentActions } from "../../../../../../../Redux/actionCreators";
 import LinkProvider from "./LinkProvider";
 import { userProfileRoutes } from "../../../../../../UserProfile";
 import { orderTypes } from "./PaymentPopup";
+import { anyPendingTxn } from "../../../../../../../Redux/reducers/PaymentReducer";
 
 export const paymentTitles = {
   CREATE_WALLET: "Create General Account Wallet",
@@ -22,7 +23,7 @@ export const paymentTitles = {
 };
 
 const GeneralAccountWallet = props => {
-  const { classes, channelInfo, handleContinue, paypalInProgress, anyGeneralWallet } = props;
+  const { classes, channelInfo, handleContinue, paypalInProgress, anyGeneralWallet, anyPendingTxn } = props;
 
   const [showCreateWalletPopup, setShowCreateWalletPopup] = useState(false);
   const [showTopupWallet, setShowTopupWallet] = useState(false);
@@ -45,11 +46,11 @@ const GeneralAccountWallet = props => {
     }
   }, [paypalInProgress.orderType]);
 
-  const anyPendingTxn = () => {
-    const { wallet } = props;
-    const anyPending = wallet.transactions && wallet.transactions.some(txn => txn.status === "PENDING");
-    return anyPending;
-  };
+  // const anyPendingTxn = () => {
+  //   const { wallet } = props;
+  //   const anyPending = wallet.transactions && wallet.transactions.some(txn => txn.status === "PENDING");
+  //   return anyPending;
+  // };
 
   return (
     <Fragment>
@@ -84,6 +85,7 @@ const mapStateToProps = state => ({
   paypalInProgress: state.paymentReducer.paypalInProgress,
   wallet: state.userReducer.wallet,
   anyGeneralWallet: anyGeneralWallet(state),
+  anyPendingTxn: anyPendingTxn(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/ServiceDetails/AboutService/ServiceDemo/index.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/index.js
@@ -15,6 +15,7 @@ import Routes from "../../../../utility/constants/Routes";
 import { initSdk, initPaypalSdk } from "../../../../utility/sdk";
 import { walletTypes } from "../../../../Redux/actionCreators/UserActions";
 import { channelInfo } from "../../../../Redux/reducers/UserReducer";
+import { anyPendingTxn } from "../../../../Redux/reducers/PaymentReducer";
 
 const demoProgressStatus = {
   purchasing: 1,
@@ -47,12 +48,19 @@ class ServiceDemo extends Component {
   };
 
   componentDidUpdate = async prevProps => {
-    const { wallet, channelInfo } = this.props;
+    const { wallet, channelInfo, anyPendingTxn, stopWalletDetailsPolling } = this.props;
     if (wallet.type === walletTypes.METAMASK) {
       await initSdk();
     }
-    if (wallet.type === walletTypes.GENERAL && prevProps.channelInfo.id !== channelInfo.id) {
-      initPaypalSdk(wallet.address, channelInfo);
+    if (wallet.type === walletTypes.GENERAL) {
+      if (prevProps.channelInfo.id !== channelInfo.id) {
+        initPaypalSdk(wallet.address, channelInfo);
+      }
+      if (!anyPendingTxn) {
+        stopWalletDetailsPolling();
+        return;
+      }
+      this.pollWalletDetails();
     }
   };
 
@@ -206,6 +214,7 @@ const mapStateToProps = state => ({
   wallet: state.userReducer.wallet,
   firstTimeFetchWallet: state.userReducer.firstTimeFetchWallet,
   channelInfo: channelInfo(state),
+  anyPendingTxn: anyPendingTxn(state),
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => ({


### PR DESCRIPTION
- initialized walletPollInterval with `false`;
- setInterval will assign some `Int` to the walletPollInterval, which is truthy
- so walletPollInterval is checked before starting or stopping polling
- In the serviceDemo, if wallet type is general, anyPendingTxn is checked
- if anyPendingTxn is false, then stopPolling will be called and the func is returned
- else the startPolling is called