### PR TITLE
initializing paypalSDK if wallet changes

### DIFF
--- a/src/components/ServiceDetails/AboutService/ServiceDemo/index.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/index.js
@@ -53,7 +53,7 @@ class ServiceDemo extends Component {
       await initSdk();
     }
     if (wallet.type === walletTypes.GENERAL) {
-      if (prevProps.channelInfo.id !== channelInfo.id) {
+      if (prevProps.channelInfo.id !== channelInfo.id || prevProps.wallet.type !== wallet.type) {
         initPaypalSdk(wallet.address, channelInfo);
       }
       if (!anyPendingTxn) {


### PR DESCRIPTION
previously we were checking whether the wallet is GENERAL and whether the channelId has changed. but channelId is getting changed even before the wallet is chenged to type GENERAL. so paypalSDK init was not happening. Now we are not only checking whether the channelId has changed, but also whether the wallet's type has been changed. if either is true, then we initialize the paypalSDK