### PR TITLE
Fix: Icon in notification bar

### DIFF
--- a/src/components/common/NotificationBar/index.js
+++ b/src/components/common/NotificationBar/index.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/styles";
 import Grid from "@material-ui/core/Grid";
 import clsx from "clsx";
+import isEmpty from "lodash/isEmpty";
 
 import { useStyles } from "./styles";
 
@@ -23,7 +24,7 @@ const NotificationBar = ({ classes, showNotification, icon: Icon, message, type 
         lg={12}
         className={clsx(classes.notificationText, classes[notificationBarTypes[type]])}
       >
-        {Icon & <Icon />}
+        {!isEmpty(Icon) && <Icon />}
         <span>{message}</span>
       </Grid>
     </Grid>


### PR DESCRIPTION
checking if the icon is being empty and rendering it. Previously just a and condition rendered the symbol as '0'