### PR TITLE
updated:USD to AGI conversion rate

### DIFF
--- a/src/utility/PricingStrategy.js
+++ b/src/utility/PricingStrategy.js
@@ -3,7 +3,7 @@ const priceData = {
   fixed_price_per_method: "fixed_price_per_method",
   agi_precision: 100000000,
   agi_divisibility: 8,
-  usd_conv_rate: 0.00000001,
+  usd_conv_rate: 0.000001,
 };
 
 const priceModelNames = {


### PR DESCRIPTION
1 USD now translates to 100 cogs and 1 AGI is 10^8 cogs so usd_conv_rate which represents USD to AGI is updated as 0.000001

modified:   src/utility/PricingStrategy.js