### PR TITLE
Feature error handling

### DIFF
--- a/src/components/ServiceDetails/AboutService/ServiceDemo/index.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/index.js
@@ -138,9 +138,15 @@ class ServiceDemo extends Component {
   };
 
   serviceRequestErrorHandler = error => {
+    const alert = { type: alertTypes.ERROR };
+    if (error.response && error.response.data && error.response.data.error) {
+      alert.message = error.response.data.error;
+    } else {
+      alert.message = error.message;
+    }
     this.setState({
       isServiceExecutionComplete: false,
-      alert: { type: alertTypes.ERROR, message: "Service Execution went wrong. Please try again" },
+      alert,
     });
     this.props.stopLoader();
   };

--- a/src/utility/sdk.js
+++ b/src/utility/sdk.js
@@ -164,7 +164,7 @@ export const initSdk = async address => {
     return Promise.resolve(sdk);
   }
 
-  if (sdk) {
+  if (sdk && !(sdk instanceof PaypalSDK)) {
     return Promise.resolve(sdk);
   }
 

--- a/src/utility/sdk.js
+++ b/src/utility/sdk.js
@@ -248,18 +248,21 @@ export const createServiceClient = (
       serviceRequestStartHandler();
     }
   };
-
-  return {
-    invoke(methodDescriptor, props) {
-      requestStartHandler();
-      serviceClient.invoke(methodDescriptor, { ...props, onEnd: onEnd(props) });
-    },
-    unary(methodDescriptor, props) {
-      requestStartHandler();
-      serviceClient.unary(methodDescriptor, { ...props, onEnd: onEnd(props) });
-    },
-    getMethodNames,
-  };
+  try {
+    return {
+      invoke(methodDescriptor, props) {
+        requestStartHandler();
+        serviceClient.invoke(methodDescriptor, { ...props, onEnd: onEnd(props) });
+      },
+      unary(methodDescriptor, props) {
+        requestStartHandler();
+        serviceClient.unary(methodDescriptor, { ...props, onEnd: onEnd(props) });
+      },
+      getMethodNames,
+    };
+  } catch (error) {
+    serviceRequestErrorHandler(error);
+  }
 };
 
 export default sdk;


### PR DESCRIPTION
### [error handling for serviceRequest error](https://github.com/singnet/snet-dapp/commit/5c239b847abda37d173648be2065e76204981a2b)
checking for if any error from API or else displaying `error.message` . wrap invoke and unary with try catch and throwing the error.

### [before initializing sdk checking whether it is an instance of Paypal SDK](https://github.com/singnet/snet-dapp/commit/de6c96fb1fa5e95ea634051cdf8e261d5f5f5e74)
MM sdk was checking if any sdk exists and returning the same.
but it was returning the same even if the SDK is of type Paypal.
so checking if `sdk instance of PaypalSDK` and if so creating new sdk
