### PR TITLE
Fixing web3 when REACT_APP_WEB3_PROVIDER is not provided.

### DIFF
--- a/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/PaymentPopup/Details/index.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/PaymentPopup/Details/index.js
@@ -26,7 +26,9 @@ import AGITokens from "./AGITokens";
 export const paymentTypes = [{ value: "paypal", label: "Paypal" }];
 const paymentAmounts = [{ value: 2, label: "2" }, { value: 3, label: "3" }, { value: 5, label: "5" }];
 
-const web3 = new Web3(process.env.REACT_APP_WEB3_PROVIDER, null, {});
+const web3 = process.env.REACT_APP_WEB3_PROVIDER
+  ? new Web3(process.env.REACT_APP_WEB3_PROVIDER, null, {})
+  : window.web3;
 
 const description = {
   [orderTypes.CREATE_WALLET]: `Please enter the payment type in the box below, along with the amount you would 

--- a/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/PaymentPopup/VerifyKey/index.js
+++ b/src/components/ServiceDetails/AboutService/ServiceDemo/Purchase/ExpiredSession/GeneralAccountWallet/PaymentPopup/VerifyKey/index.js
@@ -15,7 +15,9 @@ const warningMessage = [
   `You won't be able to Link your wallet with any new providers`,
 ];
 
-const web3 = new Web3(process.env.REACT_APP_WEB3_PROVIDER, null, {});
+const web3 = process.env.REACT_APP_WEB3_PROVIDER
+  ? new Web3(process.env.REACT_APP_WEB3_PROVIDER, null, {})
+  : window.web3;
 
 const VerifyKey = ({ classes, handleLostPrivateKey, walletList, handleUserProvidedPrivateKey, handleNextSection }) => {
   const [keyLost, setKeyLost] = useState(false);


### PR DESCRIPTION
When user doesn't set the `REACT_APP_WEB3_PROVIDER` key in `.env` file, the code:
```
const web3 = new Web3(process.env.REACT_APP_WEB3_PROVIDER, null, {});
```
Crashes with error:

![image](https://user-images.githubusercontent.com/15108323/74744233-a9e58f80-5240-11ea-8ed4-e115fde67170.png)
