### PR TITLE
[services-ui] Removing a bunch of warnings from Outlined* components.

### DIFF
--- a/src/assets/thirdPartyServices/common/OutlinedTextArea.js
+++ b/src/assets/thirdPartyServices/common/OutlinedTextArea.js
@@ -57,20 +57,20 @@ class OutlinedTextArea extends React.Component {
             name={name}
             type={type}
             inputRef={this.inputRef}
-            multiline={multiline}
             label={label ? label : null}
             value={value}
+            multiline={multiline ? multiline : rows > 1 ? true : false}
             rows={rows ? rows : null}
             variant="outlined"
             margin="normal"
-            fullWidth={fullWidth}
+            fullWidth={fullWidth ? fullWidth : true}
             onChange={onChange}
             onFocus={onFocus}
             helperText={helperTxt ? helperTxt : null}
             inputProps={{
               maxLength: charLimit ? charLimit : 5000,
-              min: min ? min : null,
-              max: max ? max : null,
+              min: typeof(min) === "number" ? min : null,
+              max: typeof(max) === "number" ? max : null,
             }}
             ref={ref}
           />

--- a/src/assets/thirdPartyServices/snet/cntk_image_recon/index.js
+++ b/src/assets/thirdPartyServices/snet/cntk_image_recon/index.js
@@ -11,22 +11,17 @@ import SNETImageUpload from "../../standardComponents/SNETImageUpload";
 import { Recognizer } from "./image_recon_pb_service";
 
 const initialUserInput = {
-  methodIndex: 0,
+  methodIndex: "0",
   methodNames: [
-    {
-      label: "Select a method",
-      content: "Select a method",
-      value: 0,
-    },
     {
       label: "Flowers",
       content: "flowers",
-      value: 1,
+      value: "0",
     },
     {
       label: "Dogs",
       content: "dogs",
-      value: 2,
+      value: "1",
     },
   ],
 
@@ -45,13 +40,13 @@ export default class CNTKImageRecognition extends React.Component {
       users_guide: "https://singnet.github.io/dnn-model-services/users_guide/cntk-image-recon.html",
       code_repo: "https://github.com/singnet/dnn-model-services/tree/master/services/cntk-image-recon",
       reference: "https://cntk.ai/pythondocs/CNTK_301_Image_Recognition_with_Deep_Transfer_Learning.html",
-      model: "ResNet152",
       response: undefined,
     };
   }
 
   canBeInvoked() {
-    return this.state.img_path && this.state.methodName !== "Select a method";
+    if(this.state.img_path) return true;
+    return false;
   }
 
   getImageData(data) {
@@ -63,12 +58,12 @@ export default class CNTKImageRecognition extends React.Component {
   }
 
   submitAction() {
-    const { methodIndex, methodNames, img_path, model } = this.state;
+    const { methodIndex, methodNames, img_path } = this.state;
     const methodDescriptor = Recognizer[methodNames[methodIndex].content];
     const request = new methodDescriptor.requestType();
 
     request.setImgPath(img_path);
-    request.setModel(model);
+    request.setModel("ResNet152");
 
     const props = {
       request,
@@ -87,7 +82,7 @@ export default class CNTKImageRecognition extends React.Component {
     return (
       <React.Fragment>
         <Grid container spacing={2} justify="center" alignItems="center">
-          <Grid item xs={12} container justify="left" style={{ textAlign: "center" }}>
+          <Grid item xs={12} container justify="center" style={{ textAlign: 'center' }}>
             <OutlinedDropDown
               id="method"
               name="methodIndex"

--- a/src/assets/thirdPartyServices/snet/cntk_language_understanding/index.js
+++ b/src/assets/thirdPartyServices/snet/cntk_language_understanding/index.js
@@ -14,19 +14,14 @@ const initialUserInput = {
   methodIndex: "0",
   methodNames: [
     {
-      label: "Select a method",
-      content: "Select a method",
-      value: "0",
-    },
-    {
       label: "Slot Tagging",
       content: "slot_tagging",
-      value: "1",
+      value: "0",
     },
     {
       label: "Intent Classification",
       content: "intent",
-      value: "2",
+      value: "1",
     },
   ],
 
@@ -53,7 +48,6 @@ export default class CNTKLanguageUnderstanding extends React.Component {
         "https://github.com/singnet/nlp-services/blob/master/docs/users_guide/cntk-language-understanding.md",
       code_repo: "https://github.com/singnet/nlp-services/blob/master/cntk-language-understanding",
       reference: "https://cntk.ai/pythondocs/CNTK_202_Language_Understanding.html",
-
       response: undefined,
     };
   }
@@ -67,8 +61,7 @@ export default class CNTKLanguageUnderstanding extends React.Component {
       this.isValidURL(this.state.train_ctf_url, ".ctf") &&
       this.isValidURL(this.state.test_ctf_url, ".ctf") &&
       this.isValidURL(this.state.query_wl_url, ".wl") &&
-      this.isValidURL(this.state.sentences_url, ".txt") &&
-      this.state.methodIndex !== 0
+      this.isValidURL(this.state.sentences_url, ".txt")
     );
   }
 
@@ -134,7 +127,6 @@ export default class CNTKLanguageUnderstanding extends React.Component {
           <Grid item xs={8} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="train_ctf_url"
-              ref={this.textInput}
               name="train_ctf_url"
               label="Train CTF (URL)"
               type="text"
@@ -148,7 +140,6 @@ export default class CNTKLanguageUnderstanding extends React.Component {
           <Grid item xs={8} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="test_ctf_url"
-              ref={this.textInput}
               name="test_ctf_url"
               label="Test CTF (URL)"
               type="text"
@@ -162,7 +153,6 @@ export default class CNTKLanguageUnderstanding extends React.Component {
           <Grid item xs={8} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="query_wl_url"
-              ref={this.textInput}
               name="query_wl_url"
               label="Query List (URL)"
               type="text"
@@ -176,7 +166,6 @@ export default class CNTKLanguageUnderstanding extends React.Component {
           <Grid item xs={8} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="slots_wl_url"
-              ref={this.textInput}
               name="slots_wl_url"
               label="Slots List (URL)"
               type="text"
@@ -190,7 +179,6 @@ export default class CNTKLanguageUnderstanding extends React.Component {
           <Grid item xs={8} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="intent_wl_url"
-              ref={this.textInput}
               name="intent_wl_url"
               label="Intent List (URL)"
               type="text"
@@ -212,7 +200,6 @@ export default class CNTKLanguageUnderstanding extends React.Component {
                 min={1}
                 fullWidth={true}
                 onChange={this.handleFormUpdate}
-                ref={this.textInput}
               />
             </Grid>
             <Grid item xs>
@@ -225,7 +212,6 @@ export default class CNTKLanguageUnderstanding extends React.Component {
                 min={1}
                 fullWidth={true}
                 onChange={this.handleFormUpdate}
-                ref={this.textInput}
               />
             </Grid>
             <Grid item xs>
@@ -238,7 +224,6 @@ export default class CNTKLanguageUnderstanding extends React.Component {
                 min={1}
                 fullWidth={true}
                 onChange={this.handleFormUpdate}
-                ref={this.textInput}
               />
             </Grid>
           </Grid>
@@ -246,7 +231,6 @@ export default class CNTKLanguageUnderstanding extends React.Component {
           <Grid item xs={8} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="sentences_url"
-              ref={this.textInput}
               name="sentences_url"
               label="Sentences (URL)"
               type="text"

--- a/src/assets/thirdPartyServices/snet/cntk_lstm_forecast/index.js
+++ b/src/assets/thirdPartyServices/snet/cntk_lstm_forecast/index.js
@@ -14,19 +14,14 @@ const initialUserInput = {
   sourceIndex: "0",
   sourceTypes: [
     {
-      label: "Select Source",
-      content: "Select Source",
-      value: "0",
-    },
-    {
       label: "Financial",
       content: "financial",
-      value: "1",
+      value: "0",
     },
     {
       label: "CSV File",
       content: "csv",
-      value: "2",
+      value: "1",
     },
   ],
 
@@ -53,7 +48,6 @@ export default class CNTKLSTMForecast extends React.Component {
         "https://github.com/singnet/time-series-analysis/blob/master/docs/users_guide/generic/cntk-lstm-forecast.md",
       code_repo: "https://github.com/singnet/time-series-analysis/blob/master/generic/cntk-lstm-forecast",
       reference: "https://cntk.ai/pythondocs/CNTK_106B_LSTM_Timeseries_with_IOT_Data.html",
-
       response: undefined,
     };
   }
@@ -142,7 +136,6 @@ export default class CNTKLSTMForecast extends React.Component {
           <Grid item xs={8} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="source"
-              ref={this.textInput}
               name="source"
               label="CSV File URL"
               type="text"
@@ -156,7 +149,6 @@ export default class CNTKLSTMForecast extends React.Component {
           <Grid item xs={8} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="contract"
-              ref={this.textInput}
               name="contract"
               label="Contract (Financial)"
               type="text"
@@ -178,7 +170,6 @@ export default class CNTKLSTMForecast extends React.Component {
                 min={1}
                 fullWidth={true}
                 onChange={this.handleFormUpdate}
-                ref={this.textInput}
               />
             </Grid>
             <Grid item xs>
@@ -191,7 +182,6 @@ export default class CNTKLSTMForecast extends React.Component {
                 min={1}
                 fullWidth={true}
                 onChange={this.handleFormUpdate}
-                ref={this.textInput}
               />
             </Grid>
             <Grid item xs>
@@ -204,7 +194,6 @@ export default class CNTKLSTMForecast extends React.Component {
                 min={1}
                 fullWidth={true}
                 onChange={this.handleFormUpdate}
-                ref={this.textInput}
               />
             </Grid>
           </Grid>
@@ -213,7 +202,6 @@ export default class CNTKLSTMForecast extends React.Component {
             <Grid item xs>
               <OutlinedTextArea
                 id="start_date"
-                ref={this.textInput}
                 name="start_date"
                 label="Start Date"
                 type="date"
@@ -227,7 +215,6 @@ export default class CNTKLSTMForecast extends React.Component {
             <Grid item xs>
               <OutlinedTextArea
                 id="end_date"
-                ref={this.textInput}
                 name="end_date"
                 label="End Date"
                 type="date"

--- a/src/assets/thirdPartyServices/snet/cntk_next_day_trend/index.js
+++ b/src/assets/thirdPartyServices/snet/cntk_next_day_trend/index.js
@@ -11,12 +11,12 @@ import OutlinedTextArea from "../../common/OutlinedTextArea";
 import { NextDayTrend } from "./next_day_trend_pb_service";
 
 const initialUserInput = {
-  sourceIndex: 0,
+  sourceIndex: "0",
   sourceNames: [
     {
       label: "Yahoo! Finance",
       content: "yahoo",
-      value: 0,
+      value: "0",
     },
   ],
 
@@ -32,17 +32,12 @@ export default class CNTKNextDayTrend extends React.Component {
     this.submitAction = this.submitAction.bind(this);
     this.handleFormUpdate = this.handleFormUpdate.bind(this);
 
-    this.textInput = React.createRef();
-
     this.state = {
       ...initialUserInput,
       users_guide:
         "https://github.com/singnet/time-series-analysis/blob/master/docs/users_guide/finance/cntk-next-day-trend.md",
       code_repo: "https://github.com/singnet/time-series-analysis/blob/master/finance/cntk-next-day-trend",
       reference: "https://cntk.ai/pythondocs/CNTK_104_Finance_Timeseries_Basic_with_Pandas_Numpy.html",
-
-      serviceName: "NextDayTrend",
-      methodName: "trend",
       response: undefined,
     };
     this.isComplete = false;
@@ -60,8 +55,8 @@ export default class CNTKNextDayTrend extends React.Component {
   }
 
   submitAction() {
-    const { methodName, sourceIndex, sourceNames, contract, start, end, target_date } = this.state;
-    const methodDescriptor = NextDayTrend[methodName];
+    const { sourceIndex, sourceNames, contract, start, end, target_date } = this.state;
+    const methodDescriptor = NextDayTrend["trend"];
     const request = new methodDescriptor.requestType();
 
     request.setSource(sourceNames[sourceIndex].content);
@@ -87,7 +82,7 @@ export default class CNTKNextDayTrend extends React.Component {
     return (
       <React.Fragment>
         <Grid container direction="column" alignItems="center" justify="center">
-          <Grid item xs={4} container style={{ textAlign: "center" }}>
+          <Grid item xs={6} container style={{ textAlign: "center" }}>
             <OutlinedDropDown
               id="source"
               name="sourceIndex"
@@ -99,10 +94,9 @@ export default class CNTKNextDayTrend extends React.Component {
             />
           </Grid>
 
-          <Grid item xs={4} container style={{ textAlign: "center" }}>
+          <Grid item xs={6} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="contract"
-              ref={this.textInput}
               name="contract"
               label="Contract (Ticker)"
               type="text"
@@ -113,35 +107,34 @@ export default class CNTKNextDayTrend extends React.Component {
             />
           </Grid>
 
-          <Grid item xs={4} container style={{ textAlign: "center" }}>
-            <OutlinedTextArea
-              id="start"
-              ref={this.textInput}
-              name="start"
-              label="Start Date"
-              type="date"
-              fullWidth={true}
-              value={this.state.start}
-              rows={1}
-              onChange={this.handleFormUpdate}
-            />
-          </Grid>
-
-          <Grid item xs={4} container style={{ textAlign: "center" }}>
-            <OutlinedTextArea
-              id="end"
-              ref={this.textInput}
-              name="end"
-              label="End Date"
-              type="date"
-              InputLabelProps={{
-                shrink: true,
-              }}
-              fullWidth={true}
-              value={this.state.end}
-              rows={1}
-              onChange={this.handleFormUpdate}
-            />
+          <Grid item xs={6} container spacing={1}>
+            <Grid item xs>
+              <OutlinedTextArea
+                id="start"
+                name="start"
+                label="Start Date"
+                type="date"
+                fullWidth={true}
+                value={this.state.start}
+                rows={1}
+                onChange={this.handleFormUpdate}
+              />
+            </Grid>
+            <Grid item xs>
+              <OutlinedTextArea
+                id="end"
+                name="end"
+                label="End Date"
+                type="date"
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                fullWidth={true}
+                value={this.state.end}
+                rows={1}
+                onChange={this.handleFormUpdate}
+              />
+            </Grid>
           </Grid>
 
           <Grid item xs container justify="flex-end">

--- a/src/assets/thirdPartyServices/snet/example_service/index.js
+++ b/src/assets/thirdPartyServices/snet/example_service/index.js
@@ -8,16 +8,31 @@ import OutlinedTextArea from "../../common/OutlinedTextArea";
 import { Calculator } from "./example_service_pb_service";
 
 const initialUserInput = {
-  methodIndex: 0,
-  methodNames: {
-    0: "Select a method",
-    1: "add",
-    2: "sub",
-    3: "mul",
-    4: "div",
-  },
-  a: 0,
-  b: 0,
+  methodIndex: "0",
+  methodNames: [
+    {
+      label: "Addition",
+      content: "add",
+      value: "0",
+    },
+    {
+      label: "Subtraction",
+      content: "sub",
+      value: "1",
+    },
+    {
+      label: "Multiplication",
+      content: "mul",
+      value: "2",
+    },
+    {
+      label: "Division",
+      content: "div",
+      value: "3",
+    }
+  ],
+  a: "0",
+  b: "0",
 };
 
 export default class ExampleService extends React.Component {
@@ -25,14 +40,7 @@ export default class ExampleService extends React.Component {
     super(props);
     this.submitAction = this.submitAction.bind(this);
     this.handleFormUpdate = this.handleFormUpdate.bind(this);
-
-    this.textInput = React.createRef();
-
     this.state = { ...initialUserInput };
-  }
-
-  canBeInvoked() {
-    return this.state.methodIndex !== 0;
   }
 
   handleFormUpdate(event) {
@@ -52,7 +60,8 @@ export default class ExampleService extends React.Component {
   }
 
   submitAction() {
-    const methodDescriptor = Calculator[this.state.methodNames[this.state.methodIndex]];
+    const { methodIndex, methodNames } = this.state;
+    const methodDescriptor = Calculator[methodNames[methodIndex].content];
     const request = new methodDescriptor.requestType();
     request.setA(this.state.a);
     request.setB(this.state.b);
@@ -66,78 +75,58 @@ export default class ExampleService extends React.Component {
     this.props.serviceClient.unary(methodDescriptor, props);
   }
 
-  renderServiceMethodNames(serviceMethodNames) {
-    const serviceNameOptions = ["Select a method", ...serviceMethodNames];
-    const serviceMap = {
-      "Select a method": "Select a method",
-      add: "Addition",
-      sub: "Subtraction",
-      mul: "Multiplication",
-      div: "Division",
-    };
-    return serviceNameOptions.map((serviceMethodName, index) => {
-      return {
-        label: serviceMap[serviceMethodName],
-        content: serviceMap[serviceMethodName],
-        value: index,
-      };
-    });
-  }
-
   handleFocus = event => event.target.select();
 
   renderForm() {
-    const serviceMethodNames = this.props.serviceClient.getMethodNames(Calculator);
-    const methodNamesList = this.renderServiceMethodNames(serviceMethodNames);
     return (
       <React.Fragment>
-        <Grid container direction="column" justify="center">
-          <Grid item xs={4} style={{ textAlign: "left" }}>
+        <Grid container direction="column" alignItems="center" justify="center">
+          <Grid item xs={6} container style={{ textAlign: "center" }}>
             <OutlinedDropDown
               id="method"
               name="methodIndex"
               label="Method"
               fullWidth={true}
-              list={methodNamesList}
+              list={this.state.methodNames}
               value={this.state.methodIndex}
               onChange={this.handleFormUpdate}
             />
           </Grid>
 
-          <Grid item xs={4} style={{ textAlign: "left" }}>
-            <OutlinedTextArea
-              id="number_a"
-              ref={this.textInput}
-              name="a"
-              label="Number 1"
-              type="number"
-              fullWidth={false}
-              value={this.state.a}
-              rows={1}
-              onChange={this.handleFormUpdate}
-              onKeyPress={e => this.onKeyPressvalidator(e)}
-              onFocus={this.handleFocus}
-            />
-          </Grid>
+          <Grid item xs={6} container spacing={1}>
+            <Grid item xs>
+              <OutlinedTextArea
+                id="number_a"
+                name="a"
+                label="Number 1"
+                type="number"
+                fullWidth={false}
+                value={this.state.a}
+                rows={1}
+                onChange={this.handleFormUpdate}
+                onKeyPress={e => this.onKeyPressvalidator(e)}
+                onFocus={this.handleFocus}
+              />
+            </Grid>
 
-          <Grid item xs={4} style={{ textAlign: "left" }}>
-            <OutlinedTextArea
-              id="number_b"
-              ref={this.textInput}
-              name="b"
-              label="Number 2"
-              type="number"
-              fullWidth={false}
-              value={this.state.b}
-              rows={1}
-              onChange={this.handleFormUpdate}
-              onKeyPress={e => this.onKeyPressvalidator(e)}
-              onFocus={this.handleFocus}
-            />
+            <Grid item xs>
+              <OutlinedTextArea
+                id="number_b"
+                name="b"
+                label="Number 2"
+                type="number"
+                fullWidth={false}
+                value={this.state.b}
+                rows={1}
+                onChange={this.handleFormUpdate}
+                onKeyPress={e => this.onKeyPressvalidator(e)}
+                onFocus={this.handleFocus}
+              />
+            </Grid>
           </Grid>
 
           <Grid item xs={12} style={{ textAlign: "center" }}>
-            <Button variant="contained" color="primary" onClick={this.submitAction} disabled={!this.canBeInvoked()}>
+            <Button variant="contained" color="primary" onClick={this.submitAction}>
               Invoke
             </Button>
           </Grid>
@@ -159,9 +148,9 @@ export default class ExampleService extends React.Component {
   renderComplete() {
     const response = this.parseResponse();
     return (
-      <div>
-        <p style={{ fontSize: "13px" }}>Response from service is {response} </p>
-      </div>
+      <Grid item xs={12} container justify="center">
+        <p style={{ fontSize: "20px" }}>Response from service: {response} </p>
+      </Grid>
     );
   }
 

--- a/src/assets/thirdPartyServices/snet/face_align/index.js
+++ b/src/assets/thirdPartyServices/snet/face_align/index.js
@@ -37,14 +37,10 @@ export default class FaceAlignService extends React.Component {
   submitAction() {
     const methodDescriptor = FaceAlignment.AlignFace;
     const request = new methodDescriptor.requestType();
-
     const header = new FaceAlignmentHeader();
-
     var bbList = [];
-    //var bb = new BoundingBox(JSON.parse(this.state.facesString)[0])
 
     var inputBoudingBox = JSON.parse(this.state.facesString);
-
     inputBoudingBox.forEach(item => {
       var bb = new BoundingBox();
       bb.setX(JSON.parse(item.x));
@@ -128,12 +124,10 @@ export default class FaceAlignService extends React.Component {
           <Grid item xs={12} container justify="center" style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="facesString"
-              ref={this.textInput}
               name="facesString"
               label="Bounding Boxes (from Detect Faces)"
               type="text"
               fullWidth={true}
-              multiline={true}
               value={this.state.facesString}
               rows={8}
               onChange={this.handleFormUpdate}

--- a/src/assets/thirdPartyServices/snet/face_detect/index.js
+++ b/src/assets/thirdPartyServices/snet/face_detect/index.js
@@ -169,12 +169,10 @@ export default class FaceDetectService extends React.Component {
             <Grid item xs={12} container justify="center" style={{ textAlign: "center" }}>
               <OutlinedTextArea
                 id="response_bboxes"
-                ref={this.textInput}
                 name="response_bboxes"
                 label="Bounding Boxes"
                 type="text"
                 fullWidth={true}
-                multiline={true}
                 value={JSON.stringify(this.state.response.image_chunk.faceBboxList, null, "\t")}
                 rows={8}
               />

--- a/src/assets/thirdPartyServices/snet/face_identity/index.js
+++ b/src/assets/thirdPartyServices/snet/face_identity/index.js
@@ -277,12 +277,10 @@ export default class FaceIdentityService extends React.Component {
             <Grid item xs={12} container justify="center" style={{ textAlign: "center" }}>
               <OutlinedTextArea
                 id="facesString"
-                ref={this.textInput}
                 name="facesString"
                 label="Bounding Boxes (from Detect Faces)"
                 type="text"
                 fullWidth={true}
-                multiline={true}
                 value={this.state.facesString}
                 rows={8}
                 onChange={this.handleFormUpdate}
@@ -297,12 +295,10 @@ export default class FaceIdentityService extends React.Component {
                   <Grid key={idx} item xs>
                     <OutlinedTextArea
                       id={"vector_" + idx}
-                      ref={this.textInput}
                       name={"vector_" + idx}
                       label="Raw Vector"
                       type="text"
                       fullWidth={true}
-                      multiline={true}
                       value={JSON.stringify(item.identityList)}
                       rows={4}
                     />

--- a/src/assets/thirdPartyServices/snet/face_landmarks/index.js
+++ b/src/assets/thirdPartyServices/snet/face_landmarks/index.js
@@ -223,12 +223,10 @@ export default class FaceLandmarksService extends React.Component {
             <Grid item xs={12} container justify="center" style={{ textAlign: "center" }}>
               <OutlinedTextArea
                 id="facesString"
-                ref={this.textInput}
                 name="facesString"
                 label="Bounding Boxes (from Detect Faces)"
                 type="text"
                 fullWidth={true}
-                multiline={true}
                 value={this.state.facesString}
                 rows={8}
                 onChange={this.handleFormUpdate}
@@ -240,12 +238,10 @@ export default class FaceLandmarksService extends React.Component {
             <Grid item xs={12} container justify="center" style={{ textAlign: "center" }}>
               <OutlinedTextArea
                 id="landmarks"
-                ref={this.textInput}
                 name="landmarks"
                 label="Landmarks"
                 type="text"
                 fullWidth={true}
-                multiline={true}
                 value={JSON.stringify(this.state.response.image_chunk.landmarkedFacesList, null, "\t")}
                 rows={8}
               />

--- a/src/assets/thirdPartyServices/snet/i3d_video_action_recognition/index.js
+++ b/src/assets/thirdPartyServices/snet/i3d_video_action_recognition/index.js
@@ -11,20 +11,19 @@ import OutlinedTextArea from "../../common/OutlinedTextArea";
 import { VideoActionRecognition } from "./video_action_recon_pb_service";
 
 const initialUserInput = {
-  modelIndex: 0,
+  modelIndex: "0",
   modelNames: [
     {
       label: "Kinetics-400",
       content: "400",
-      value: 0,
+      value: "0",
     },
     {
       label: "Kinetics-600",
       content: "600",
-      value: 1,
+      value: "1",
     },
   ],
-
   url: "",
 };
 
@@ -32,10 +31,7 @@ export default class I3DActionRecognition extends React.Component {
   constructor(props) {
     super(props);
     this.submitAction = this.submitAction.bind(this);
-
     this.handleFormUpdate = this.handleFormUpdate.bind(this);
-
-    this.textInput = React.createRef();
 
     this.state = {
       ...initialUserInput,
@@ -43,9 +39,6 @@ export default class I3DActionRecognition extends React.Component {
         "https://github.com/singnet/dnn-model-services/blob/master/docs/users_guide/i3d-video-action-recognition.md",
       code_repo: "https://github.com/singnet/dnn-model-services/tree/master/services/i3d-video-action-recognition",
       reference: "https://github.com/deepmind/kinetics-i3d",
-
-      serviceName: "VideoActionRecognition",
-      methodName: "video_action_recon",
       response: undefined,
     };
 
@@ -68,8 +61,8 @@ export default class I3DActionRecognition extends React.Component {
   }
 
   submitAction() {
-    const { methodName, modelIndex, modelNames, url } = this.state;
-    const methodDescriptor = VideoActionRecognition[methodName];
+    const { modelIndex, modelNames, url } = this.state;
+    const methodDescriptor = VideoActionRecognition["video_action_recon"];
     const request = new methodDescriptor.requestType();
 
     request.setModel(modelNames[modelIndex].content);
@@ -107,7 +100,6 @@ export default class I3DActionRecognition extends React.Component {
           <Grid item xs={12} style={{ textAlign: "left" }}>
             <OutlinedTextArea
               id="url"
-              ref={this.textInput}
               name="url"
               label="Video URL (.avi, .mp4 or YouTube)"
               value={this.state.url}

--- a/src/assets/thirdPartyServices/snet/news_summary/index.js
+++ b/src/assets/thirdPartyServices/snet/news_summary/index.js
@@ -13,13 +13,9 @@ export default class NewSummaryService extends React.Component {
     this.handleFormUpdate = this.handleFormUpdate.bind(this);
 
     const initialUserInput = {
-      serviceName: "TextSummary",
-      methodName: "summary",
       article_content:
         'Analysts are predicting record highs as a global shortage of teddy bears sweeps the nation. "The market these products is way up". The advice is to stay indoors as society collapses under the demand.',
     }
-
-    this.textInput = React.createRef();
 
     this.state = { 
       ...initialUserInput,
@@ -37,8 +33,8 @@ export default class NewSummaryService extends React.Component {
   }
 
   submitAction() {
-     const { methodName, article_content } = this.state;
-    const methodDescriptor = TextSummary[methodName];
+     const { article_content } = this.state;
+    const methodDescriptor = TextSummary["summary"];
     const request = new methodDescriptor.requestType();
 
     request.setArticleContent(article_content)
@@ -65,7 +61,6 @@ export default class NewSummaryService extends React.Component {
           <Grid item xs={12} style={{ textAlign: "left" }}>
             <OutlinedTextArea
               id="article_content"
-              ref={this.textInput}
               name="article_content"
               label="News text to summarize:"
               fullWidth={true}
@@ -93,11 +88,9 @@ export default class NewSummaryService extends React.Component {
         
       <React.Fragment>
         <Grid container direction="column" justify="center">
-
           <Grid item xs={12} style={{ textAlign: "left" }}>
             <OutlinedTextArea
               id="article_summary"
-              ref={this.textInput}
               name="article_summary"
               label="Summarization:"
               fullWidth={true}

--- a/src/assets/thirdPartyServices/snet/openmt_romance_translator/index.js
+++ b/src/assets/thirdPartyServices/snet/openmt_romance_translator/index.js
@@ -120,7 +120,6 @@ export default class OpenNMTRomanceTranslator extends React.Component {
           <Grid item xs={8} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="sentences_url"
-              ref={this.textInput}
               name="sentences_url"
               label="Sentences (or URL with text)"
               type="text"

--- a/src/assets/thirdPartyServices/snet/s2vt_video_captioning/index.js
+++ b/src/assets/thirdPartyServices/snet/s2vt_video_captioning/index.js
@@ -15,28 +15,16 @@ export default class S2VTVideoCaptioning extends React.Component {
     this.submitAction = this.submitAction.bind(this);
     this.handleFormUpdate = this.handleFormUpdate.bind(this);
 
-    this.textInput = React.createRef();
-
     this.state = {
       users_guide:
         "https://github.com/singnet/dnn-model-services/blob/master/docs/users_guide/s2vt-video-captioning.md",
       code_repo: "https://github.com/singnet/dnn-model-services/tree/master/services/s2vt-video-captioning",
       reference: "https://vsubhashini.github.io/s2vt.html",
-
-      serviceName: "VideoCaptioning",
-      methodName: "video_cap",
-
       url: "",
       start_time_sec: "0",
       stop_time_sec: "0",
-
       response: undefined,
-      isComplete: false,
     };
-    this.isComplete = false;
-    this.serviceMethods = [];
-    this.allServices = [];
-    this.methodsForAllServices = [];
   }
 
   isValidVideoURL(str) {
@@ -58,8 +46,8 @@ export default class S2VTVideoCaptioning extends React.Component {
   }
 
   submitAction() {
-    const { methodName, url, start_time_sec, stop_time_sec } = this.state;
-    const methodDescriptor = VideoCaptioning[methodName];
+    const { url, start_time_sec, stop_time_sec } = this.state;
+    const methodDescriptor = VideoCaptioning["video_cap"];
     const request = new methodDescriptor.requestType();
 
     request.setUrl(url);
@@ -91,7 +79,6 @@ export default class S2VTVideoCaptioning extends React.Component {
           <Grid item xs={12} style={{ textAlign: "left" }}>
             <OutlinedTextArea
               id="url"
-              ref={this.textInput}
               name="url"
               label="Video URL (.avi, .mp4 or YouTube)"
               value={this.state.url}
@@ -101,34 +88,36 @@ export default class S2VTVideoCaptioning extends React.Component {
             />
           </Grid>
 
-          <Grid item xs={4} style={{ textAlign: "left" }}>
-            <OutlinedTextArea
-              id="standard-number"
-              ref={this.textInput}
-              name="start_time_sec"
-              label="StartTime (s):"
-              type="number"
-              fullWidth={false}
-              value={this.state.start_time_sec}
-              rows={1}
-              onChange={this.handleFormUpdate}
-              onFocus={this.handleFocus}
-            />
-          </Grid>
+          <Grid item xs={12} container spacing={1}>
+            <Grid item xs>
+              <OutlinedTextArea
+                id="standard-number"
+                name="start_time_sec"
+                label="StartTime (s):"
+                type="number"
+                fullWidth={false}
+                value={this.state.start_time_sec}
+                min={0}
+                rows={1}
+                onChange={this.handleFormUpdate}
+                onFocus={this.handleFocus}
+              />
+            </Grid>
 
-          <Grid item xs={4} style={{ textAlign: "left" }}>
-            <OutlinedTextArea
-              id="filled-number"
-              ref={this.textInput}
-              name="stop_time_sec"
-              label="EndTime (s):"
-              type="number"
-              fullWidth={false}
-              value={this.state.stop_time_sec}
-              rows={1}
-              onChange={this.handleFormUpdate}
-              onFocus={this.handleFocus}
-            />
+            <Grid item xs>
+              <OutlinedTextArea
+                id="filled-number"
+                name="stop_time_sec"
+                label="EndTime (s):"
+                type="number"
+                fullWidth={false}
+                value={this.state.stop_time_sec}
+                min={0}
+                rows={1}
+                onChange={this.handleFormUpdate}
+                onFocus={this.handleFocus}
+              />
+            </Grid>
           </Grid>
 
           <Grid item xs container justify="flex-end">

--- a/src/assets/thirdPartyServices/snet/semantic_segmentation/index.js
+++ b/src/assets/thirdPartyServices/snet/semantic_segmentation/index.js
@@ -11,7 +11,6 @@ import { SemanticSegmentation } from "./segmentation_pb_service";
 import { Image } from "./segmentation_pb";
 
 const initialUserInput = {
-  methodName: "segment",
   mimetype: undefined,
   imageData: undefined,
 };
@@ -65,8 +64,8 @@ export default class SemanticSegmentationService extends React.Component {
   }
 
   submitAction() {
-    const { methodName, imageData, mimetype, visualise } = this.state;
-    const methodDescriptor = SemanticSegmentation[methodName];
+    const { imageData, mimetype, visualise } = this.state;
+    const methodDescriptor = SemanticSegmentation["segment"];
     const request = new methodDescriptor.requestType();
 
     // Setting the Proto Message Img

--- a/src/assets/thirdPartyServices/snet/translation/index.js
+++ b/src/assets/thirdPartyServices/snet/translation/index.js
@@ -116,7 +116,6 @@ export default class TranslationService extends React.Component {
           <Grid item xs={8} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="text"
-              ref={this.textInput}
               name="text"
               label="Text to translate"
               type="text"

--- a/src/assets/thirdPartyServices/snet/yolov3_object_detection/index.js
+++ b/src/assets/thirdPartyServices/snet/yolov3_object_detection/index.js
@@ -29,16 +29,8 @@ export default class YOLOv3ObjectDetection extends React.Component {
         "https://github.com/singnet/dnn-model-services/blob/master/docs/users_guide/yolov3-object-detection.md",
       code_repo: "https://github.com/singnet/dnn-model-services/tree/master/services/yolov3-object-detection",
       reference: "https://pjreddie.com/darknet/yolo/",
-      serviceName: "Detect",
-      methodName: "detect",
-      model: "yolov3",
       response: undefined,
     };
-
-    this.isComplete = false;
-    this.serviceMethods = [];
-    this.allServices = [];
-    this.methodsForAllServices = [];
   }
 
   getImageURL(data) {
@@ -58,12 +50,12 @@ export default class YOLOv3ObjectDetection extends React.Component {
   }
 
   submitAction() {
-    const { methodName, img_path, model, confidence } = this.state;
-    const methodDescriptor = Detect[methodName];
+    const { img_path, confidence } = this.state;
+    const methodDescriptor = Detect["detect"];
     const request = new methodDescriptor.requestType();
 
     request.setImgPath(img_path);
-    request.setModel(model);
+    request.setModel("yolov3");
     request.setConfidence(confidence);
 
     const props = {
@@ -114,21 +106,24 @@ export default class YOLOv3ObjectDetection extends React.Component {
         <Grid container spacing={3} direction="column" justify="center" alignItems="center">
           <Grid item xs={12} />
           {!this.props.isComplete && (
-            <Grid item xs={12} style={{ textAlign: "center", width: "100%" }}>
-              Confidence ({this.state.confidence.toFixed(2)}):{" "}
-              <Slider
-                style={{ padding: "15px 0px", width: "100%" }}
-                value={this.state.confidence}
-                min={0.05}
-                max={1.0}
-                step={0.05}
-                fullWidth
-                onChange={this.handleSliderChange}
-              />
+            <Grid item xs={8} container justify="center">
+              <Grid item xs>
+                Confidence ({this.state.confidence.toFixed(2)}):{" "}
+              </Grid>
+              <Grid item xs>
+                <Slider
+                  style={{ padding: "12px 0px" }}
+                  value={this.state.confidence}
+                  min={0.05}
+                  max={1.0}
+                  step={0.05}
+                  onChange={this.handleSliderChange}
+                />
+              </Grid>
             </Grid>
           )}
 
-          <Grid item xs={12} style={{ textAlign: "center" }}>
+          <Grid item xs={12} container justify="center">
             <SNETImageUpload
               imageName=""
               imageDataFunc={this.getImageURL}
@@ -136,7 +131,7 @@ export default class YOLOv3ObjectDetection extends React.Component {
               outputImageName="Response"
               instantUrlFetch={true}
               allowURL={true}
-              width="90%"
+              width="100%"
             />
           </Grid>
 

--- a/src/assets/thirdPartyServices/snet/zeta36_chess_alpha_zero/index.js
+++ b/src/assets/thirdPartyServices/snet/zeta36_chess_alpha_zero/index.js
@@ -11,20 +11,19 @@ import OutlinedDropDown from "../../common/OutlinedDropdown";
 import { AlphaZero } from "./alpha_zero_pb_service";
 
 const initialUserInput = {
-  cmdIndex: 0,
+  cmdIndex: "0",
   cmdNames: [
     {
       label: "",
       content: "",
-      value: 0,
+      value: "0",
     },
     {
       label: "Restart",
       content: "Restart",
-      value: 1,
+      value: "1",
     },
   ],
-
   uid: "",
   move: "",
 };
@@ -41,9 +40,6 @@ export default class Zeta36ChessAlphaZero extends React.Component {
         "https://github.com/singnet/dnn-model-services/blob/master/docs/users_guide/zeta36-chess-alpha-zero.md",
       code_repo: "https://github.com/singnet/dnn-model-services/tree/master/services/zeta36-chess-alpha-zero",
       reference: "https://github.com/Zeta36/chess-alpha-zero",
-
-      serviceName: "AlphaZero",
-      methodName: "play",
       response: undefined,
     };
   }
@@ -63,8 +59,8 @@ export default class Zeta36ChessAlphaZero extends React.Component {
   }
 
   submitAction() {
-    const { methodName, uid, move, cmdIndex, cmdNames } = this.state;
-    const methodDescriptor = AlphaZero[methodName];
+    const { uid, move, cmdIndex, cmdNames } = this.state;
+    const methodDescriptor = AlphaZero["play"];
     const request = new methodDescriptor.requestType();
 
     request.setUid(uid);
@@ -96,31 +92,31 @@ export default class Zeta36ChessAlphaZero extends React.Component {
     return (
       <React.Fragment>
         <Grid container spacing={2} justify="center" alignItems="center">
-          <Grid item xs={12} justify="left" style={{ textAlign: "center" }}>
+          <Grid item xs={12} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="uid"
-              ref={this.textInput}
               name="uid"
               label="UID (keep playing the same game)"
+              fullWidth={true}
               value={this.state.uid}
               rows={1}
               onChange={this.handleFormUpdate}
             />
           </Grid>
 
-          <Grid item xs={12} justify="left" style={{ textAlign: "center" }}>
+          <Grid item xs={12} container style={{ textAlign: "center" }}>
             <OutlinedTextArea
               id="move"
-              ref={this.textInput}
               name="move"
               label="Move (eg: c2c4)"
+              fullWidth={true}
               value={this.state.move}
               rows={1}
               onChange={this.handleFormUpdate}
             />
           </Grid>
 
-          <Grid item xs={8} justify="left" style={{ textAlign: "center" }}>
+          <Grid item xs={12} container style={{ textAlign: "center" }}>
             <OutlinedDropDown
               id="cmd"
               name="cmdIndex"


### PR DESCRIPTION
- Changing index type from `number` to `string` to remove warnings at `OutlinedDropDown` values.
- Removing `ref` from all Outlined* components (warnings).
- Better logic for the following `OutlinedTextArea` props:
  - `multiline`
  - `fullWidth`
  - `min` and `max`