### PR TITLE
Fix: Sandbox environment check fail

### DIFF
--- a/src/components/ServiceDetails/AboutService/DemoToggler.js
+++ b/src/components/ServiceDetails/AboutService/DemoToggler.js
@@ -69,7 +69,7 @@ const DemoToggler = ({
     );
   }
 
-  if (process.env.REACT_APP_SANDBOX !== true && noDemoComponent) {
+  if (process.env.REACT_APP_SANDBOX !== "true" && noDemoComponent) {
     return (
       <div className={classes.serviceOfflineContainer} ref={demoExampleRef}>
         <h2>Demo Example</h2>


### PR DESCRIPTION
Fix `process.env.REACT_APP_SANDBOX` is always string and failing while checking truth condition